### PR TITLE
A bug regarding arguments for Net::FTPFXPTLS.new

### DIFF
--- a/lib/ftpfxp/ftpfxptls.rb
+++ b/lib/ftpfxp/ftpfxptls.rb
@@ -39,6 +39,9 @@ module Net
 	class FTPFXPTLS < FTPFXP
 		include OpenSSL
 
+		MODE_TLS_AUTH = 0
+		MODE_SSL_AUTH = 1
+
 		# When +true+, transfers are performed securely. Default: +true+.
 		attr_reader :secure_on
 		attr_accessor :client_cert
@@ -50,7 +53,7 @@ module Net
 		# If a block is given, it is passed the +FTP+ object, which will be closed
 		# when the block finishes, or when an exception is raised.
 		#
-		def FTPFXPTLS.open(host, user = nil, passwd = nil, mode = 0, acct = nil)
+		def FTPFXPTLS.open(host, user = nil, passwd = nil, mode = MODE_TLS_AUTH, acct = nil)
 			ftpfxptls = new(host)
 			if user
 				ftpfxptls.login(user, passwd, mode, acct)
@@ -70,13 +73,13 @@ module Net
 		# This method authenticates a user with the ftp server connection.
 		# If no +username+ given, defaults to +anonymous+.
 		# If no +mode+ given, defaults to +TLS AUTH+.
-		# - mode = 0 for +TLS+ (default)
-		# - mode = 1 for +SSL+
+		# - mode = MODE_TLS_AUTH for +TLS+ (default)
+		# - mode = MODE_SSL_AUTH for +SSL+
 		#
-		def login(user = "anonymous", passwd = nil, mode = 0, acct = nil)
+		def login(user = "anonymous", passwd = nil, mode = MODE_TLS_AUTH, acct = nil)
 			# SSL/TLS context.
 			ctx = create_ssl_context()
-			if 1 == mode
+			if MODE_SSL_AUTH == mode
 				voidcmd('AUTH SSL')
 			else
 				voidcmd('AUTH TLS')

--- a/lib/ftpfxp/ftpfxptls.rb
+++ b/lib/ftpfxp/ftpfxptls.rb
@@ -51,15 +51,18 @@ module Net
 		# when the block finishes, or when an exception is raised.
 		#
 		def FTPFXPTLS.open(host, user = nil, passwd = nil, mode = 0, acct = nil)
+			ftpfxptls = new(host)
+			if user
+				ftpfxptls.login(user, passwd, mode, acct)
+			end
 			if block_given?
-				ftpfxptls = new(host, user, passwd, mode, acct)
 				begin
 					yield ftpfxptls
 				ensure
 					ftpfxptls.close
 				end
 			else
-				new(host, user, passwd, mode, acct)
+				ftpfxptls
 			end
 		end
 


### PR DESCRIPTION
I have encountered an error in below script:

```
require 'ftpfxp'

Net::FTPFXPTLS.open('example.net, 'user', 'passwd') do |ftp|
  ftp.passive = true
  puts ftp.ls
end
```

Error message:
    c:/ruby/lib/ruby/gems/1.9.1/gems/ftpfxp-0.0.4/lib/ftpfxp/ftpfxptls.rb:53:in `new': wrong number of arguments (5 for 4) (ArgumentError)
           from c:/ruby/lib/ruby/gems/1.9.1/gems/ftpfxp-0.0.4/lib/ftpfxp/ftpfxptls.rb:53:in`open'
           from bug_of_ftpfxptls.rb:3:in `<main>'

I fixed the bug, so could you accept my pull request?
Thanks,
(and I'm sorry for my poor English)

KITAITI Makoto.
